### PR TITLE
sc-35838 add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @muxinc/community-engineering
-/CODEOWNERS @muxinc/platform-team
+/CODEOWNERS @muxinc/platform-engineering


### PR DESCRIPTION
sc-35838

In case you are wondering where this is coming from, I'm trying to get repo's assigned to teams so we can establish service ownership which is helpful for a number of reasons. from a security perspective, we can route security-related issues with this repo to the owning team. the idea is to use CODEOWNERS file as that source of truth.

If needed we can also include additional teams but it requires at least one.

https://www.notion.so/mux/Github-ef1921fcf1e34d9ea513c1019d9aa558#a18fe967813345d98789b0f36e5116af