### PR TITLE
Scope revalidations more accurately

### DIFF
--- a/contexts/VideoContext.tsx
+++ b/contexts/VideoContext.tsx
@@ -319,13 +319,13 @@ export const getStaticVideoProps: GetStaticProps<
       props: {
         initialVideos: entryVideos,
       },
-      revalidate: process.env.VERCEL_ENV !== "production" && 30,
+      revalidate: process.env.VERCEL_URL !== "guestbook.mux.dev" && 30,
     };
   }
   return {
     props: {
       initialVideos: [],
     },
-    revalidate: process.env.VERCEL_ENV !== "production" && 30,
+    revalidate: process.env.VERCEL_URL !== "guestbook.mux.dev" && 30,
   };
 };

--- a/pages/entry/[id].tsx
+++ b/pages/entry/[id].tsx
@@ -178,7 +178,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
       playback_id,
       aspect_ratio,
     },
-    revalidate: process.env.VERCEL_ENV !== "production" && 30,
+    revalidate: process.env.VERCEL_URL !== "guestbook.mux.dev" && 30,
   };
 };
 


### PR DESCRIPTION
Previously, revalidations were scoped to production. However, not all production environments are hit by the /api/revalidate webhook. Only guestbook.mux.dev gets hit. Everywhere else, let's set revalidate === 30